### PR TITLE
 Improve log deletion 

### DIFF
--- a/log-cleanup/airflow-log-cleanup.py
+++ b/log-cleanup/airflow-log-cleanup.py
@@ -97,6 +97,7 @@ start = DummyOperator(
     dag=dag)
 
 log_cleanup = """
+set -e
 
 echo "Getting Configurations..."
 BASE_LOG_FOLDER="{{params.directory}}"

--- a/log-cleanup/airflow-log-cleanup.py
+++ b/log-cleanup/airflow-log-cleanup.py
@@ -101,6 +101,14 @@ start = DummyOperator(
 log_cleanup = """
 set -e
 
+trap 'error_handler $? $LINENO' ERR
+
+error_handler() {
+  echo "Error: ($1) occurred on $2"
+  echo "Deleting lock file..."
+  rm -f """ + str(LOG_CLEANUP_PROCESS_LOCK_FILE) + """
+}
+
 echo "Getting Configurations..."
 BASE_LOG_FOLDER="{{params.directory}}"
 WORKER_SLEEP_TIME="{{params.sleep_time}}"


### PR DESCRIPTION
- do not use wildcards `*` as it fails when there are two many logs to delete
- Use a `find -delete` command to improve performance
- make the task fail as soon as an error happens (using [`set -e`](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html))
- use less verbose logs by default
- 
An alternative to this script would be to use the DAG from this blog post: https://eatcodeplay.com/a-simple-dag-to-quickly-purge-old-airflow-logs-274ed5de1567